### PR TITLE
Fix geo.distance and null comparison support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ let sortedQuery =
     }
 ```
 
-You can also perform sorting on geo-location distance. This sort normally is performed in conjunction with a `GeoFilter` filter.
+You can also perform sorting on geo-location distance. This sort normally is performed in conjunction with a `GeoDistanceFilter` filter.
 
 ```fsharp
 let sortedGeoQuery =
     azureSearch {
         // Sort by furthest away from London
-        sort [ ByDistance(-0.127758, 51.507351, Descending) ]
+        sort [ ByDistance("Geo", -0.127758, 51.507351, Descending) ]
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -106,20 +106,20 @@ There are also some simple helpers to make create common filters easier:
 let filter = whereEq("Age", 21)
 ```
 
-### Geo filtering
-Azure Search supports geo filtering, and this is exposed in Kibalta:
+### Geo distance filtering
+Azure Search supports geo distance filtering, and this is exposed in Kibalta:
 
 ```fsharp
 let withinTenKmOfLondon =
     azureSearch {
-        filter (whereGeo (-0.127758, 51.507351) Lt 10.)
+        filter (whereGeoDistance "Geo" (-0.127758, 51.507351) Lt 10.)
     }
 ```
 
 Again, you can manually construct the filter expression if you wish:
 
 ```fsharp
-let asFilterExpr = GeoFilter (-0.127758, 51.507351, Lt, 10.)
+let asFilterExpr = GeoDistanceFilter ("Geo", -0.127758, 51.507351, Lt, 10.)
 ```
 
 ### Composing filters programmatically

--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ There are also some simple helpers to make create common filters easier:
 let filter = whereEq("Age", 21)
 ```
 
+You can filter based on whether values exist for a field by comparing the field to null:
+
+```fsharp
+let myQuery =
+    azureSearch {
+        filter (where "Age" Ne null)
+    }
+```
+
+This works in both directions, so if you want to find all documents that do not have a value for a certain field, you can do this:
+
+```fsharp
+let filter = whereEq("Age", null)
+``` 
+
 ### Geo distance filtering
 Azure Search supports geo distance filtering, and this is exposed in Kibalta:
 

--- a/src/Kibalta.fs
+++ b/src/Kibalta.fs
@@ -49,7 +49,7 @@ module Filters =
     
     type FilterExpr =
         | FieldFilter of field: string * FilterComparison * value: obj
-        | GeoFilter of long: float * lat: float * FilterComparison * distance: float
+        | GeoDistanceFilter of field: string * long: float * lat: float * FilterComparison * distance: float
         | BinaryFilter of FilterExpr * FilterCombiner * FilterExpr
         
         /// ANDs two filters together
@@ -62,7 +62,7 @@ module Filters =
     // A helper to create a basic field filter.
     let where a comp b = FieldFilter(a, comp, b)
     // A helper to create a basic geo filter.
-    let whereGeo (long, lat) comp b = GeoFilter(long, lat, comp, b)
+    let whereGeoDistance field (long, lat) comp b = GeoDistanceFilter(field, long, lat, comp, b)
     
     /// Combines two filters by ANDing them together.
     let combine = List.fold (+) DefaultFilter
@@ -77,8 +77,8 @@ module Filters =
             match value with
             | :? string as s -> sprintf "%s %s '%s'" field comparison.StringValue s
             | s -> sprintf "%s %s %O" field comparison.StringValue s
-        | GeoFilter(long, lat, comparison, distance) -> 
-            let lhs = sprintf "geo.distance(Geo, geography'POINT(%f %f)')" long lat
+        | GeoDistanceFilter(field, long, lat, comparison, distance) -> 
+            let lhs = sprintf "geo.distance(%s, geography'POINT(%f %f)')" field long lat
             sprintf "%s %s %f" lhs comparison.StringValue distance
         | BinaryFilter(left, And, right) -> sprintf "%s and %s" (eval left) (eval right)
         | BinaryFilter(left, Or, right) -> sprintf "%s or %s" (eval left) (eval right)

--- a/src/Kibalta.fs
+++ b/src/Kibalta.fs
@@ -17,12 +17,12 @@ type Direction =
 /// Specifies a type of sort to apply.
 type SortColumn =
     | ByField of field: string * Direction
-    | ByDistance of long: float * lat: float * Direction
+    | ByDistance of field: string * long: float * lat: float * Direction
     member this.StringValue =
         match this with
         | ByField(field, dir) -> sprintf "%s %s" field dir.StringValue
-        | ByDistance(long, lat, dir) -> 
-            sprintf "geo.distance(Geo, geography'POINT(%f %f)') %s" long lat dir.StringValue
+        | ByDistance(field, long, lat, dir) -> 
+            sprintf "geo.distance(%s, geography'POINT(%f %f)') %s" field long lat dir.StringValue
 
 module Filters =
     /// Combines two filters together using either AND or OR logic.


### PR DESCRIPTION
This PR fixes three issues I found:
  1. geo.distance filtering only worked for fields named "Geo"
  2. Same for geo.distance sorting
  3. Filtering by comparing a field to null wasn't supported, since it was being used to implement `DefaultFilter`.